### PR TITLE
Fix crash when settings include {"basename": true}

### DIFF
--- a/jump.lua
+++ b/jump.lua
@@ -11,7 +11,7 @@ function init()
 end
 
 function jumptagCommand(bp) -- bp BufPane
-		local filename = bp.Buf.GetName(bp.Buf)
+		local filename = bp.Buf.Path
 		local cmd = string.format("bash -c \"ctags -f - --fields=n '%s'|fzf|tr ':' '\n'|tail -1\"", filename)
 		local out = shell.RunInteractiveShell(cmd, false, true)
 		local linenum = tonumber(out)-1


### PR DESCRIPTION
Since the plugin was passing the result of `Buf.GetName()` to `ctags`, if settings included `{"basename": true}`, the buffer's full path would be lost and the filename would not resolve. This uses `Buf.Path` instead, which should be equivalent because `GetPath` only seems to add handling of cases like an empty name that wouldn't work in either case.